### PR TITLE
add logic to post data to serviceworker for app shell2

### DIFF
--- a/src/lib/service-worker-data.js
+++ b/src/lib/service-worker-data.js
@@ -1,0 +1,25 @@
+/* @flow */
+const INITIAL_DATA_CHANNEL_NAME = 'initial-data-channel';
+
+// eslint-disable-next-line compat/compat
+const broadcast = new BroadcastChannel(INITIAL_DATA_CHANNEL_NAME);
+
+
+export function cacheInitialData(token : string) : void {
+  const {
+    xprops: {
+      buyerCountry = '',
+      locale = {}
+    } = {}
+  } = window;
+  const data = {
+    token: token,
+    areCookiesDisabled: false,
+    isIframe: false,
+    country: buyerCountry || 'US',
+    countryCodeAsString: buyerCountry || 'US',
+    languageCode: `${locale.lang}`
+  }
+
+  broadcast.postMessage(data);
+}

--- a/src/props/createOrder.js
+++ b/src/props/createOrder.js
@@ -9,6 +9,7 @@ import { createOrderID, billingTokenToOrderID, subscriptionIdToCartId, createPay
 import { FPTI_STATE, FPTI_TRANSITION, FPTI_CONTEXT_TYPE } from '../constants';
 import { getLogger, isEmailAddress } from '../lib';
 import { ENABLE_PAYMENT_API } from '../config';
+import { cacheInitialData } from '../lib/service-worker-data';
 
 import type { CreateSubscription } from './createSubscription';
 import type { CreateBillingAgreement } from './createBillingAgreement';
@@ -178,7 +179,11 @@ export function getCreateOrder({ createOrder, intent, currency, merchantID, part
             } else if (createSubscription) {
                 return createSubscription().then(subscriptionIdToCartId);
             } else if (createOrder) {
-                return createOrder(data, actions);
+                return createOrder(data, actions)
+                    .then(orderId => {
+                        cacheInitialData(orderId);
+                        return orderId;
+                    });
             } else {
                 return actions.order.create({
                     purchase_units: [


### PR DESCRIPTION
### Description
- The goal of app shell2 to to trigger an early initial data call and store it in indexedDB to save time on app load
- These changes post the necessary variables to the service-worker on button click to start that process
<!-- Ensure you have a PR description that answers: What? Why? How? -->
<!-- Example PR Description: https://www.pullrequest.com/blog/writing-a-great-pull-request-description/ -->

### Why are we making these changes? Include references to any related Jira tasks or GitHub Issues

### Reproduction Steps (if applicable)

### Screenshots (if applicable)

### Dependent Changes (if applicable)

<!-- If this PR depends on changes to other applications, document those dependencies (ex: paypal-checkout-components). -->
<!-- Are there any additional considerations when deploying this change to production? -->

❤️  Thank you!
